### PR TITLE
Rewrite token exchange requests with js instead of proxies.json

### DIFF
--- a/FunctionApp/Functions/TokenExchange.cs
+++ b/FunctionApp/Functions/TokenExchange.cs
@@ -13,12 +13,7 @@ namespace Coomes.Equipper.FunctionApp
 {
     public static class TokenExchange
     {
-        // see https://github.com/Azure/static-web-apps/issues/165
-        // todo: when issue fixed: 
-        //   change this back to 'TokenExchange' 
-        //   remove the proxy in proxies.json
-        //   change param back to 'code'
-        [FunctionName("TokenExchangeWorkaround")]
+        [FunctionName("TokenExchange")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
             ILogger log)
@@ -27,7 +22,7 @@ namespace Coomes.Equipper.FunctionApp
                 var correlationID = Guid.NewGuid();
                 log.LogInformation("{function} {status} {cid}", "TokenExchange", "Starting", correlationID.ToString());
 
-                string code = req.Query["_code"]; // see proxies.json and https://github.com/Azure/static-web-apps/issues/165
+                string code = req.Query["_code"]; // see https://github.com/Azure/static-web-apps/issues/165 and auth.html
                 string scopeString = req.Query["scope"];
                 string error = req.Query["error"];
 

--- a/FunctionApp/proxies.json
+++ b/FunctionApp/proxies.json
@@ -1,17 +1,6 @@
 {
     "$schema": "http://json.schemastore.org/proxies",
     "proxies": {
-        "tokenExchange": {
-            "matchCondition": {
-                "methods": [ "GET" ],
-                "route": "/api/TokenExchange"
-            },
-            "backendUri": "https://localhost/api/TokenExchangeWorkaround",
-            "requestOverrides": {
-              "backend.request.querystring.code": "",
-              "backend.request.querystring._code": "{request.querystring.code}"
-            }
-        },
         "secureSubscriptionCallback" : {
             "matchCondition": {
                 "methods": [ "GET", "POST" ],

--- a/Website/auth.html
+++ b/Website/auth.html
@@ -70,8 +70,15 @@
       }
     }, 600);
     
-    var params = window.location.search;
-    fetch(`/api/tokenExchange${params}`)
+    // rewrite code parameter if it exists. See https://github.com/Azure/static-web-apps/issues/165
+    let params = (new URL(document.location)).searchParams;
+    if (params.has("code")) {
+      let codeValue = params.get("code")
+      params.set("_code", codeValue)
+      params.delete("code")
+    }
+
+    fetch(`/api/TokenExchange?${params.toString()}`)
     .then(result => {
       if(result.ok) {
         document.getElementById("authPendingSection").style.display = "none";


### PR DESCRIPTION
Closes #38 

Use javascript in auth.html to rewrite the token parameter from 'code' to '_code' to avoid the known issue with static web apps not processing requests containing a 'code' parameter: https://github.com/Azure/static-web-apps/issues/165

This works around the SWA issue without using proxies.json, which is not supported in functions v4. 