### PR TITLE
Revert dark mode support. Use arial font.

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -77,7 +77,7 @@
       <h2 id="contact" class="section__header">Contact & Support</h2>
       <p>
         Equipper is proudly developed and supported by Ben Coomes. 
-        If you find a problem or have a suggestion, send him an email at <a class="section__link" href="mailto:equipperapp@gmail.com">equipperapp@gmail.com</a>
+        If you find a problem or have a suggestion, send him an email at <a class="section__link" href="mailto:equipperapp@gmail.com">equipperapp@gmail.com</a> or open an <a href="https://github.com/benCoomes/equipper/issues">issue</a>.
         If you'd like to contribute yourself, Equipper is open source. Check it out on <a class="section__link" href="https://github.com/benCoomes/equipper">GitHub</a>!
       </p>
     </section>

--- a/Website/styles.css
+++ b/Website/styles.css
@@ -1,7 +1,7 @@
 :root {
     --menu-bg-color: #af322e;
     --menu-color: white;
-    --body-bg-color: #fffce8;
+    --body-bg-color: #fffef9;
     --body-color: #231f24;
     --accent-color: #b8b42d;
     --success-color: #425003;
@@ -9,24 +9,11 @@
     --active-brightness: .2;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --menu-bg-color: #af322e;
-        --menu-color: white;
-        --body-bg-color: #231f24;
-        --body-color:  #fffce8;
-        --accent-color: #425003;
-        --success-color: #f5f294;
-        --error-color: #ffa3a0;
-        --active-brightness: 5;
-    }
-}
-
 .equipper {
     background-color: var(--body-bg-color);
     color: var(--body-color);
     font-size: 1.2rem;
-    font-family: 'Courier New', Courier, monospace;
+    font-family: "Arial", "Helvetica", sans-serif
 }
 
 .mainHeader {
@@ -53,6 +40,7 @@
 .brand__title {
     color: var(--menu-color);
     font-size: 3rem;
+    font-family: Courier, 'Courier New', monospace; 
 }
 
 .brand__logo { 
@@ -96,15 +84,6 @@
     color: var(--error-color);
     animation-duration: 1.5s;
     animation-name: section-fade-in;
-}
-
-.section__link {
-    color: inherit;
-}
-
-.section__link:hover, .section__link:active {
-    color: inherit;
-    filter: brightness(var(--active-brightness))
 }
 
 .section__header {


### PR DESCRIPTION
This PR removes dark mode because it slows down development of new features. It also switches the font to arial because while less fun, it is easier to read than courier.