### PR TITLE
Fix cosmos tests

### DIFF
--- a/CosmosStorageTest/TestConstants.cs
+++ b/CosmosStorageTest/TestConstants.cs
@@ -4,5 +4,7 @@ namespace Coomes.Equipper.CosmosStorage.Test
     {
         internal const string EmulatorConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         internal const string DatabaseName = "EquipperTest";
+        internal const string TokenContainerName = "TokensTest";
+        internal const string ActivityContainerName = "ActivitiesTest";
     }
 }

--- a/script/cosmosdb
+++ b/script/cosmosdb
@@ -3,10 +3,10 @@ ipaddr="`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head 
 docker run \
     --publish 8081:8081 \
     --publish 10251-10254:10251-10254 \
-    --memory 2g --cpus=2.0 \
+    --memory 4g --cpus=4.0 \
     --name=cosmosdb \
-    --env AZURE_COSMOS_EMULATOR_PARTITION_COUNT=10 \
-    --env AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true \
+    --env AZURE_COSMOS_EMULATOR_PARTITION_COUNT=4 \
+    --env AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=false \
     --env AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=$ipaddr \
     --interactive \
     --tty \


### PR DESCRIPTION
closes #43 

## Changes 
* Reuse containers between tests. To ensure test isolation, random values are used for IDs. Collisions _could_ happen but would be extraordinarily rare.
* Update comsos runtime settings
  * Don't persist memory between container restarts. This isn't necessary, or even desirable for tests.
  * Use more memory and CPU - previously we were below [recommended amounts](https://learn.microsoft.com/en-us/azure/cosmos-db/linux-emulator?tabs=sql-api%2Cssl-netstd21#configuration-options). 
