### PR TITLE
create standalone action for lighthouse audits

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,25 @@
+name: Lighthouse
+
+on:
+  workflow_dispatch:
+    inputs:
+        site_url:
+          description: 'Log level'
+          required: true
+          default: 'https://equipper.bencoomes.com'
+          type: string
+
+jobs:
+  run-lighthouse-check-job:
+    runs-on: ubuntu-latest
+    name: Run Lighthouse Check
+    steps:
+      - name: Lighthouse Audit
+        uses: jakejarvis/lighthouse-action@master
+        with:
+          url: ${{inputs.site_url}}
+      - name: Upload Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: lighthouseReport
+          path: './report'


### PR DESCRIPTION
Lighthouse audit actions are broken - this will help test if it is something wrong with the CI setup, the action, or the actual site.