### PR TITLE
remove broken lighthouse action

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-ocean-0a357fa0f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-ocean-0a357fa0f.yml
@@ -26,23 +26,12 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_KIND_OCEAN_0A357FA0F }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/Website" # App source code path
           api_location: "/FunctionApp" # Api source code path - optional
           output_location: ".github/workflows" # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
-      - name: Lighthouse Audit Live URL
-        uses: jakejarvis/lighthouse-action@master
-        with:
-          url: ${{steps.builddeploy.outputs.static_web_app_url}}
-      - name: Upload Lighthouse Results Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: lighthouseReport
-          path: './report'
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
         site_url:
-          description: 'Log level'
+          description: 'Site URL'
           required: true
           default: 'https://equipper.bencoomes.com'
           type: string
@@ -15,7 +15,7 @@ jobs:
     name: Run Lighthouse Check
     steps:
       - name: Lighthouse Audit
-        uses: jakejarvis/lighthouse-action@master
+        uses: jakejarvis/lighthouse-action@a3bcc9973b3ce65beff316b3cac53b92e58dcc12
         with:
           url: ${{inputs.site_url}}
       - name: Upload Results


### PR DESCRIPTION
Remove the lighthouse audit step from the build action, because it is now failing with a syntax error. Also, fix the param name in the dedicated lighthouse action and pin the action version.

See https://github.com/jakejarvis/lighthouse-action/issues/32